### PR TITLE
chore: add Stylelint, configuration, and fix issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
             - name: Run linting
               run: pnpm lint
 
+            - name: Run CSS linting
+              run: pnpm lint:css
+
             - name: Run tests
               run: pnpm test:ci
 

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+dist/

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
     "license": "MIT",
     "type": "module",
     "scripts": {
-        "check": "pnpm lint && pnpm test:ci && pnpm build",
+        "check": "pnpm lint && pnpm lint:css && pnpm test:ci && pnpm build",
         "dev": "vite",
         "build": "vite build",
         "lint": "oxlint",
+        "lint:css": "stylelint '**/*.{css,vue}'",
         "lint:fix": "oxlint --fix",
         "serve": "vite preview",
         "test": "vitest",
@@ -33,6 +34,13 @@
         "@vue/test-utils": "^2.0.0",
         "jsdom": "^25.0.1",
         "oxlint": "^1.55.0",
+        "postcss-html": "^1.8.1",
+        "stylelint": "^17.4.0",
+        "stylelint-config-recommended-vue": "^1.6.1",
+        "stylelint-config-standard": "^40.0.0",
+        "stylelint-plugin-defensive-css": "^2.6.0",
+        "stylelint-plugin-logical-css": "^2.0.2",
+        "stylelint-use-nesting": "^6.0.2",
         "vite": "^5.4.18",
         "vitest": "^3.0.9"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,27 @@ importers:
       oxlint:
         specifier: ^1.55.0
         version: 1.55.0
+      postcss-html:
+        specifier: ^1.8.1
+        version: 1.8.1
+      stylelint:
+        specifier: ^17.4.0
+        version: 17.4.0
+      stylelint-config-recommended-vue:
+        specifier: ^1.6.1
+        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.4.0)
+      stylelint-config-standard:
+        specifier: ^40.0.0
+        version: 40.0.0(stylelint@17.4.0)
+      stylelint-plugin-defensive-css:
+        specifier: ^2.6.0
+        version: 2.6.0(stylelint@17.4.0)
+      stylelint-plugin-logical-css:
+        specifier: ^2.0.2
+        version: 2.0.2(stylelint@17.4.0)
+      stylelint-use-nesting:
+        specifier: ^6.0.2
+        version: 6.0.2(stylelint@17.4.0)
       vite:
         specifier: ^5.4.18
         version: 5.4.21(@types/node@25.5.0)
@@ -66,6 +87,10 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -88,6 +113,12 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@cacheable/memory@2.0.8':
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
+
+  '@cacheable/utils@2.4.0':
+    resolution: {integrity: sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ==}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -98,6 +129,13 @@ packages:
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@3.1.0':
     resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
@@ -112,9 +150,46 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1':
+    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -300,6 +375,27 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -571,6 +667,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -676,6 +776,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -692,12 +795,19 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -716,13 +826,24 @@ packages:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
 
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cacheable@2.3.3:
+    resolution: {integrity: sha512-iffYMX4zxKp54evOH27fm92hs+DeC1DhXmNVN8Tr94M/iZIV42dqTHSR2Ik4TOSPyOAwKr7Yu3rN9ALoLkbWyQ==}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -739,6 +860,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -750,9 +874,31 @@ packages:
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -785,6 +931,19 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -803,6 +962,10 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -810,6 +973,13 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -845,6 +1015,23 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -856,6 +1043,16 @@ packages:
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  file-entry-cache@11.1.2:
+    resolution: {integrity: sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  flat-cache@6.1.20:
+    resolution: {integrity: sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==}
 
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
@@ -876,6 +1073,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -884,10 +1085,29 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
+  globby@16.1.1:
+    resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -897,6 +1117,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -905,9 +1129,16 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hashery@1.5.0:
+    resolution: {integrity: sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q==}
+    engines: {node: '>=20'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -915,6 +1146,13 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -928,12 +1166,50 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -972,8 +1248,15 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsdom@25.0.1:
     resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
@@ -983,6 +1266,25 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1003,6 +1305,24 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1044,6 +1364,10 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
@@ -1059,6 +1383,14 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -1081,9 +1413,36 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  postcss-html@1.8.1:
+    resolution: {integrity: sha512-OLF6P7qctfAWayOhLpcVnTGqVeJzu2W3WpIYelfz2+JV5oGxfkcEvweN9U4XpeqE0P98dcD9ssusGwlF0TK0uQ==}
+    engines: {node: ^12 || >=14}
+
+  postcss-safe-parser@6.0.0:
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1096,6 +1455,25 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qified@0.6.0:
+    resolution: {integrity: sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==}
+    engines: {node: '>=20'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1106,6 +1484,9 @@ packages:
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1138,6 +1519,14 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1156,6 +1545,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -1167,12 +1560,74 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  stylelint-config-html@1.1.0:
+    resolution: {integrity: sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==}
+    engines: {node: ^12 || >=14}
+    peerDependencies:
+      postcss-html: ^1.0.0
+      stylelint: '>=14.0.0'
+
+  stylelint-config-recommended-vue@1.6.1:
+    resolution: {integrity: sha512-lLW7hTIMBiTfjenGuDq2kyHA6fBWd/+Df7MO4/AWOxiFeXP9clbpKgg27kHfwA3H7UNMGC7aeP3mNlZB5LMmEQ==}
+    engines: {node: ^12 || >=14}
+    peerDependencies:
+      postcss-html: ^1.0.0
+      stylelint: '>=14.0.0'
+
+  stylelint-config-recommended@18.0.0:
+    resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-config-standard@40.0.0:
+    resolution: {integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-plugin-defensive-css@2.6.0:
+    resolution: {integrity: sha512-q3UAggG4r51MLfcV6mK//e+oXQIZ/5v4z+al5fOXPrrCDMSmlOMmJcOj1b32oMjFH493aSARQC82lMbUH3Mc4g==}
+    peerDependencies:
+      stylelint: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  stylelint-plugin-logical-css@2.0.2:
+    resolution: {integrity: sha512-k3AgoE0EA7RPDg+PNf3obo3HAAi4ViqEpFYWwbEsSiI1+ScNogVtBNnZ068gfXv63wybTR0XfAQE72fdHSX7Mw==}
+    peerDependencies:
+      stylelint: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  stylelint-use-nesting@6.0.2:
+    resolution: {integrity: sha512-1YeOfI7pMucTO0GKAiBOz12EaNN5qzbbboAli/jDC47nTfNsOVd9c4WmTshQnnaMDRF8ZZ0ovGzBjw0WUE4tvg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      stylelint: '>= 16.9.0'
+
+  stylelint@17.4.0:
+    resolution: {integrity: sha512-3kQ2/cHv3Zt8OBg+h2B8XCx9evEABQIrv4hh3uXahGz/ZEHrTR80zxBiK2NfXNaSoyBzxO1pjsz1Vhdzwn5XSw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
@@ -1207,6 +1662,10 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -1221,6 +1680,13 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1323,6 +1789,10 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1340,6 +1810,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -1375,6 +1849,12 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -1390,12 +1870,29 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@cacheable/memory@2.0.8':
+    dependencies:
+      '@cacheable/utils': 2.4.0
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.0':
+    dependencies:
+      hashery: 1.5.0
+      keyv: 5.6.0
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -1408,7 +1905,30 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1526,6 +2046,26 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@one-ini/wasm@0.1.1': {}
 
@@ -1665,6 +2205,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1822,6 +2364,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -1832,6 +2381,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  argparse@2.0.1: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@0.3.12:
@@ -1839,6 +2390,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  astral-regex@2.0.0: {}
 
   asynckit@0.4.0: {}
 
@@ -1854,12 +2407,26 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
   cac@6.7.14: {}
+
+  cacheable@2.3.3:
+    dependencies:
+      '@cacheable/memory': 2.0.8
+      '@cacheable/utils': 2.4.0
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.6.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  callsites@3.1.0: {}
 
   chai@5.3.3:
     dependencies:
@@ -1877,6 +2444,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colord@2.9.3: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -1888,11 +2457,27 @@ snapshots:
       ini: 1.3.8
       proto-list: 1.2.4
 
+  cosmiconfig@9.0.1:
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-functions-list@3.3.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssesc@3.0.0: {}
 
   cssstyle@4.6.0:
     dependencies:
@@ -1916,6 +2501,24 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -1935,9 +2538,17 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -1990,11 +2601,43 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-uri@3.1.0: {}
+
+  fastest-levenshtein@1.0.16: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
   fflate@0.8.2: {}
+
+  file-entry-cache@11.1.2:
+    dependencies:
+      flat-cache: 6.1.20
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  flat-cache@6.1.20:
+    dependencies:
+      cacheable: 2.3.3
+      flatted: 3.4.1
+      hookified: 1.15.1
 
   flatted@3.4.1: {}
 
@@ -2016,6 +2659,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-east-asian-width@1.5.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2034,6 +2679,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -2043,9 +2692,32 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
+  globby@16.1.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
+
   gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
+
+  has-flag@5.0.1: {}
 
   has-symbols@1.1.0: {}
 
@@ -2053,15 +2725,30 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hashery@1.5.0:
+    dependencies:
+      hookified: 1.15.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hookified@1.15.1: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-tags@5.1.0: {}
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -2081,9 +2768,34 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
+  imurmurhash@0.1.4: {}
+
   ini@1.3.8: {}
 
+  is-arrayish@0.2.1: {}
+
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -2128,7 +2840,13 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsdom@25.0.1:
     dependencies:
@@ -2158,6 +2876,20 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  kind-of@6.0.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  lodash.truncate@4.4.2: {}
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -2177,6 +2909,19 @@ snapshots:
       semver: 7.7.4
 
   math-intrinsics@1.1.0: {}
+
+  mathml-tag-names@4.0.0: {}
+
+  mdn-data@2.27.1: {}
+
+  meow@14.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
 
   mime-db@1.52.0: {}
 
@@ -2206,6 +2951,8 @@ snapshots:
     dependencies:
       abbrev: 2.0.0
 
+  normalize-path@3.0.0: {}
+
   nwsapi@2.2.23: {}
 
   oxlint@1.55.0:
@@ -2232,6 +2979,17 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -2249,7 +3007,31 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.1: {}
+
   picomatch@4.0.3: {}
+
+  postcss-html@1.8.1:
+    dependencies:
+      htmlparser2: 8.0.2
+      js-tokens: 9.0.1
+      postcss: 8.5.8
+      postcss-safe-parser: 6.0.0(postcss@8.5.8)
+
+  postcss-safe-parser@6.0.0(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
+  postcss-safe-parser@7.0.1(postcss@8.5.8):
+    dependencies:
+      postcss: 8.5.8
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.8:
     dependencies:
@@ -2260,6 +3042,18 @@ snapshots:
   proto-list@1.2.4: {}
 
   punycode@2.3.1: {}
+
+  qified@0.6.0:
+    dependencies:
+      hookified: 1.15.1
+
+  queue-microtask@1.2.3: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
 
   rollup@4.59.0:
     dependencies:
@@ -2296,6 +3090,10 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -2320,6 +3118,14 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -2338,6 +3144,11 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -2350,11 +3161,106 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.4.0):
+    dependencies:
+      postcss-html: 1.8.1
+      stylelint: 17.4.0
+
+  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.4.0):
+    dependencies:
+      postcss-html: 1.8.1
+      semver: 7.7.4
+      stylelint: 17.4.0
+      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.4.0)
+      stylelint-config-recommended: 18.0.0(stylelint@17.4.0)
+
+  stylelint-config-recommended@18.0.0(stylelint@17.4.0):
+    dependencies:
+      stylelint: 17.4.0
+
+  stylelint-config-standard@40.0.0(stylelint@17.4.0):
+    dependencies:
+      stylelint: 17.4.0
+      stylelint-config-recommended: 18.0.0(stylelint@17.4.0)
+
+  stylelint-plugin-defensive-css@2.6.0(stylelint@17.4.0):
+    dependencies:
+      stylelint: 17.4.0
+
+  stylelint-plugin-logical-css@2.0.2(stylelint@17.4.0):
+    dependencies:
+      stylelint: 17.4.0
+
+  stylelint-use-nesting@6.0.2(stylelint@17.4.0):
+    dependencies:
+      postcss-selector-parser: 7.1.1
+      stylelint: 17.4.0
+
+  stylelint@17.4.0:
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
+      colord: 2.9.3
+      cosmiconfig: 9.0.1
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.2
+      global-modules: 2.0.0
+      globby: 16.1.1
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      imurmurhash: 0.1.4
+      is-plain-object: 5.0.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.8
+      postcss-safe-parser: 7.0.1(postcss@8.5.8)
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.0
+      supports-hyperlinks: 4.4.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
+
+  svg-tags@1.0.0: {}
+
   symbol-tree@3.2.4: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.18.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   test-exclude@7.0.2:
     dependencies:
@@ -2383,6 +3289,10 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
@@ -2395,6 +3305,10 @@ snapshots:
 
   undici-types@7.18.2:
     optional: true
+
+  unicorn-magic@0.4.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite-node@3.2.4(@types/node@25.5.0):
     dependencies:
@@ -2495,6 +3409,10 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2515,6 +3433,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   ws@8.19.0: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -114,7 +114,7 @@
 
 <script setup>
     import { useStore } from 'vuex';
-    import { computed, ref } from 'vue';
+    import { computed, onMounted, ref } from 'vue';
 
     import ColorsPane from './components/ColorsPane.vue';
     import CopyModal from './components/ExportCssModal.vue';
@@ -127,6 +127,8 @@
     import UtilityButtons from './components/UtilityButtons.vue';
 
     const store = useStore();
+
+    onMounted(() => store.dispatch('LOAD_PALETTES'));
 
     const showCopyModal = ref(false);
     const showSaveModal = ref(false);
@@ -155,5 +157,5 @@
 </script>
 
 <style>
-    @import './style/app.css';
+    @import url('./style/app.css');
 </style>

--- a/src/components/SaveModal.vue
+++ b/src/components/SaveModal.vue
@@ -89,7 +89,7 @@
     const savePalette = async () => {
         if (paletteName.value) {
             try {
-                await store.dispatch('SAVE_TO_CLOUD', {
+                await store.dispatch('SAVE_PALETTE', {
                     name: paletteName.value,
                     scheme: store.getters.currentScheme,
                 });
@@ -119,5 +119,3 @@
         }
     };
 </script>
-
-<style></style>

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -1,101 +1,12 @@
+/* RESET */
+@import url('./reset.css');
+
 /*  EXTERNAL FONTS  */
 
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@100;400;600;700&family=Zen+Antique&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300&display=swap');
 
-/*  CSS CUSTOM PROPERTIES  */
-
-/* ---------------------------  */
-/* ---------- RESET ----------  */
-/* ---------------------------  */
-
-/* Box sizing rules */
-*,
-*::before,
-*::after {
-    box-sizing: border-box;
-    text-rendering: optimizeLegibility;
-}
-
-/* Remove default margin */
-body,
-h1,
-h2,
-h3,
-h4,
-p,
-figure,
-blockquote,
-dl,
-dd {
-    margin: 0;
-}
-
-h1,
-h2 {
-    font-family: 'JetBrains Mono', monospace;
-}
-
-/* Remove list styles on ul, ol elements  */
-ul,
-ol {
-    list-style: none;
-}
-
-/* Set core root defaults */
-html:focus-within {
-    scroll-behavior: smooth;
-}
-
-/* Set core body defaults */
-body {
-    min-height: 100vh;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-    line-height: 1.5;
-    color: var(--text-color);
-}
-
-/* A elements that don't have a class get default styles */
-a:not([class]) {
-    text-decoration-skip-ink: auto;
-}
-
-/* Make images easier to work with */
-img,
-picture {
-    max-width: 100%;
-    display: block;
-}
-
-/* Inherit fonts for inputs and buttons */
-input,
-button,
-textarea,
-select {
-    font: inherit;
-}
-
-/* Remove all animations, transitions and smooth scroll for people that prefer not to see them */
-@media (prefers-reduced-motion: reduce) {
-    html:focus-within {
-        scroll-behavior: auto;
-    }
-
-    *,
-    *::before,
-    *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-    }
-}
-
-/* ---------------------------  */
 /* ---- CUSTOM PROPERTIES ----  */
-/* ---------------------------  */
 
 :root {
     --clr-main: #1d1702;
@@ -106,264 +17,262 @@ select {
     --text-color: #b8a886;
     --slot-size: 120px;
     --mini-slot-size: 50px;
+    --cubic-bezier-transition: 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
     --base-radius: 0.5rem;
     --sm-radius: 0.2rem;
     --bd-lg: 1rem;
     --mb-lg: 1.5rem;
     --mb-md: 1rem;
     --mb-sm: 0.5rem;
-
     --slider-thumb-dots:
-        5px 0 0 -8px var(--clr-complementary),
-        6px 0 0 -8px var(--clr-complementary),
-        7px 0 0 -8px var(--clr-complementary),
-        8px 0 0 -8px var(--clr-complementary),
-        9px 0 0 -8px var(--clr-complementary),
-        10px 0 0 -8px var(--clr-complementary),
-        11px 0 0 -8px var(--clr-complementary),
-        12px 0 0 -8px var(--clr-complementary),
-        13px 0 0 -8px var(--clr-complementary),
-        14px 0 0 -8px var(--clr-complementary),
-        15px 0 0 -8px var(--clr-complementary),
-        16px 0 0 -8px var(--clr-complementary),
-        17px 0 0 -8px var(--clr-complementary),
-        18px 0 0 -8px var(--clr-complementary),
-        19px 0 0 -8px var(--clr-complementary),
-        20px 0 0 -8px var(--clr-complementary),
-        21px 0 0 -8px var(--clr-complementary),
-        22px 0 0 -8px var(--clr-complementary),
-        23px 0 0 -8px var(--clr-complementary),
-        24px 0 0 -8px var(--clr-complementary),
-        25px 0 0 -8px var(--clr-complementary),
-        26px 0 0 -8px var(--clr-complementary),
-        27px 0 0 -8px var(--clr-complementary),
-        28px 0 0 -8px var(--clr-complementary),
-        29px 0 0 -8px var(--clr-complementary),
-        30px 0 0 -8px var(--clr-complementary),
-        31px 0 0 -8px var(--clr-complementary),
-        32px 0 0 -8px var(--clr-complementary),
-        33px 0 0 -8px var(--clr-complementary),
-        34px 0 0 -8px var(--clr-complementary),
-        35px 0 0 -8px var(--clr-complementary),
-        36px 0 0 -8px var(--clr-complementary),
-        37px 0 0 -8px var(--clr-complementary),
-        38px 0 0 -8px var(--clr-complementary),
-        39px 0 0 -8px var(--clr-complementary),
-        40px 0 0 -8px var(--clr-complementary),
-        41px 0 0 -8px var(--clr-complementary),
-        42px 0 0 -8px var(--clr-complementary),
-        43px 0 0 -8px var(--clr-complementary),
-        44px 0 0 -8px var(--clr-complementary),
-        45px 0 0 -8px var(--clr-complementary),
-        46px 0 0 -8px var(--clr-complementary),
-        47px 0 0 -8px var(--clr-complementary),
-        48px 0 0 -8px var(--clr-complementary),
-        49px 0 0 -8px var(--clr-complementary),
-        50px 0 0 -8px var(--clr-complementary),
-        51px 0 0 -8px var(--clr-complementary),
-        52px 0 0 -8px var(--clr-complementary),
-        53px 0 0 -8px var(--clr-complementary),
-        54px 0 0 -8px var(--clr-complementary),
-        55px 0 0 -8px var(--clr-complementary),
-        56px 0 0 -8px var(--clr-complementary),
-        57px 0 0 -8px var(--clr-complementary),
-        58px 0 0 -8px var(--clr-complementary),
-        59px 0 0 -8px var(--clr-complementary),
-        60px 0 0 -8px var(--clr-complementary),
-        61px 0 0 -8px var(--clr-complementary),
-        62px 0 0 -8px var(--clr-complementary),
-        63px 0 0 -8px var(--clr-complementary),
-        64px 0 0 -8px var(--clr-complementary),
-        65px 0 0 -8px var(--clr-complementary),
-        66px 0 0 -8px var(--clr-complementary),
-        67px 0 0 -8px var(--clr-complementary),
-        68px 0 0 -8px var(--clr-complementary),
-        69px 0 0 -8px var(--clr-complementary),
-        70px 0 0 -8px var(--clr-complementary),
-        71px 0 0 -8px var(--clr-complementary),
-        72px 0 0 -8px var(--clr-complementary),
-        73px 0 0 -8px var(--clr-complementary),
-        74px 0 0 -8px var(--clr-complementary),
-        75px 0 0 -8px var(--clr-complementary),
-        76px 0 0 -8px var(--clr-complementary),
-        77px 0 0 -8px var(--clr-complementary),
-        78px 0 0 -8px var(--clr-complementary),
-        79px 0 0 -8px var(--clr-complementary),
-        80px 0 0 -8px var(--clr-complementary),
-        81px 0 0 -8px var(--clr-complementary),
-        82px 0 0 -8px var(--clr-complementary),
-        83px 0 0 -8px var(--clr-complementary),
-        84px 0 0 -8px var(--clr-complementary),
-        85px 0 0 -8px var(--clr-complementary),
-        86px 0 0 -8px var(--clr-complementary),
-        87px 0 0 -8px var(--clr-complementary),
-        88px 0 0 -8px var(--clr-complementary),
-        89px 0 0 -8px var(--clr-complementary),
-        90px 0 0 -8px var(--clr-complementary),
-        91px 0 0 -8px var(--clr-complementary),
-        92px 0 0 -8px var(--clr-complementary),
-        93px 0 0 -8px var(--clr-complementary),
-        94px 0 0 -8px var(--clr-complementary),
-        95px 0 0 -8px var(--clr-complementary),
-        96px 0 0 -8px var(--clr-complementary),
-        97px 0 0 -8px var(--clr-complementary),
-        98px 0 0 -8px var(--clr-complementary),
-        99px 0 0 -8px var(--clr-complementary),
-        100px 0 0 -8px var(--clr-complementary),
-        101px 0 0 -8px var(--clr-complementary),
-        102px 0 0 -8px var(--clr-complementary),
-        103px 0 0 -8px var(--clr-complementary),
-        104px 0 0 -8px var(--clr-complementary),
-        105px 0 0 -8px var(--clr-complementary),
-        106px 0 0 -8px var(--clr-complementary),
-        107px 0 0 -8px var(--clr-complementary),
-        108px 0 0 -8px var(--clr-complementary),
-        109px 0 0 -8px var(--clr-complementary),
-        110px 0 0 -8px var(--clr-complementary),
-        111px 0 0 -8px var(--clr-complementary),
-        112px 0 0 -8px var(--clr-complementary),
-        113px 0 0 -8px var(--clr-complementary),
-        114px 0 0 -8px var(--clr-complementary),
-        115px 0 0 -8px var(--clr-complementary),
-        116px 0 0 -8px var(--clr-complementary),
-        117px 0 0 -8px var(--clr-complementary),
-        118px 0 0 -8px var(--clr-complementary),
-        119px 0 0 -8px var(--clr-complementary),
-        120px 0 0 -8px var(--clr-complementary),
-        121px 0 0 -8px var(--clr-complementary),
-        122px 0 0 -8px var(--clr-complementary),
-        123px 0 0 -8px var(--clr-complementary),
-        124px 0 0 -8px var(--clr-complementary),
-        125px 0 0 -8px var(--clr-complementary),
-        126px 0 0 -8px var(--clr-complementary),
-        127px 0 0 -8px var(--clr-complementary),
-        128px 0 0 -8px var(--clr-complementary),
-        129px 0 0 -8px var(--clr-complementary),
-        130px 0 0 -8px var(--clr-complementary),
-        131px 0 0 -8px var(--clr-complementary),
-        132px 0 0 -8px var(--clr-complementary),
-        133px 0 0 -8px var(--clr-complementary),
-        134px 0 0 -8px var(--clr-complementary),
-        135px 0 0 -8px var(--clr-complementary),
-        136px 0 0 -8px var(--clr-complementary),
-        137px 0 0 -8px var(--clr-complementary),
-        138px 0 0 -8px var(--clr-complementary),
-        139px 0 0 -8px var(--clr-complementary),
-        140px 0 0 -8px var(--clr-complementary),
-        141px 0 0 -8px var(--clr-complementary),
-        142px 0 0 -8px var(--clr-complementary),
-        143px 0 0 -8px var(--clr-complementary),
-        144px 0 0 -8px var(--clr-complementary),
-        145px 0 0 -8px var(--clr-complementary),
-        146px 0 0 -8px var(--clr-complementary),
-        147px 0 0 -8px var(--clr-complementary),
-        148px 0 0 -8px var(--clr-complementary),
-        149px 0 0 -8px var(--clr-complementary),
-        150px 0 0 -8px var(--clr-complementary),
-        151px 0 0 -8px var(--clr-complementary),
-        152px 0 0 -8px var(--clr-complementary),
-        153px 0 0 -8px var(--clr-complementary),
-        154px 0 0 -8px var(--clr-complementary),
-        155px 0 0 -8px var(--clr-complementary),
-        156px 0 0 -8px var(--clr-complementary),
-        157px 0 0 -8px var(--clr-complementary),
-        158px 0 0 -8px var(--clr-complementary),
-        159px 0 0 -8px var(--clr-complementary),
-        160px 0 0 -8px var(--clr-complementary),
-        161px 0 0 -8px var(--clr-complementary),
-        162px 0 0 -8px var(--clr-complementary),
-        163px 0 0 -8px var(--clr-complementary),
-        164px 0 0 -8px var(--clr-complementary),
-        165px 0 0 -8px var(--clr-complementary),
-        166px 0 0 -8px var(--clr-complementary),
-        167px 0 0 -8px var(--clr-complementary),
-        168px 0 0 -8px var(--clr-complementary),
-        169px 0 0 -8px var(--clr-complementary),
-        170px 0 0 -8px var(--clr-complementary),
-        171px 0 0 -8px var(--clr-complementary),
-        172px 0 0 -8px var(--clr-complementary),
-        173px 0 0 -8px var(--clr-complementary),
-        174px 0 0 -8px var(--clr-complementary),
-        175px 0 0 -8px var(--clr-complementary),
-        176px 0 0 -8px var(--clr-complementary),
-        177px 0 0 -8px var(--clr-complementary),
-        178px 0 0 -8px var(--clr-complementary),
-        179px 0 0 -8px var(--clr-complementary),
-        180px 0 0 -8px var(--clr-complementary),
-        181px 0 0 -8px var(--clr-complementary),
-        182px 0 0 -8px var(--clr-complementary),
-        183px 0 0 -8px var(--clr-complementary),
-        184px 0 0 -8px var(--clr-complementary),
-        185px 0 0 -8px var(--clr-complementary),
-        186px 0 0 -8px var(--clr-complementary),
-        187px 0 0 -8px var(--clr-complementary),
-        188px 0 0 -8px var(--clr-complementary),
-        189px 0 0 -8px var(--clr-complementary),
-        190px 0 0 -8px var(--clr-complementary),
-        191px 0 0 -8px var(--clr-complementary),
-        192px 0 0 -8px var(--clr-complementary),
-        193px 0 0 -8px var(--clr-complementary),
-        194px 0 0 -8px var(--clr-complementary),
-        195px 0 0 -8px var(--clr-complementary),
-        196px 0 0 -8px var(--clr-complementary),
-        197px 0 0 -8px var(--clr-complementary),
-        198px 0 0 -8px var(--clr-complementary),
-        199px 0 0 -8px var(--clr-complementary),
-        200px 0 0 -8px var(--clr-complementary),
-        201px 0 0 -8px var(--clr-complementary),
-        202px 0 0 -8px var(--clr-complementary),
-        203px 0 0 -8px var(--clr-complementary),
-        204px 0 0 -8px var(--clr-complementary),
-        205px 0 0 -8px var(--clr-complementary),
-        206px 0 0 -8px var(--clr-complementary),
-        207px 0 0 -8px var(--clr-complementary),
-        208px 0 0 -8px var(--clr-complementary),
-        209px 0 0 -8px var(--clr-complementary),
-        210px 0 0 -8px var(--clr-complementary),
-        211px 0 0 -8px var(--clr-complementary),
-        212px 0 0 -8px var(--clr-complementary),
-        213px 0 0 -8px var(--clr-complementary),
-        214px 0 0 -8px var(--clr-complementary),
-        215px 0 0 -8px var(--clr-complementary),
-        216px 0 0 -8px var(--clr-complementary),
-        217px 0 0 -8px var(--clr-complementary),
-        218px 0 0 -8px var(--clr-complementary),
-        219px 0 0 -8px var(--clr-complementary),
-        220px 0 0 -8px var(--clr-complementary),
-        221px 0 0 -8px var(--clr-complementary),
-        222px 0 0 -8px var(--clr-complementary),
-        223px 0 0 -8px var(--clr-complementary),
-        224px 0 0 -8px var(--clr-complementary),
-        225px 0 0 -8px var(--clr-complementary),
-        226px 0 0 -8px var(--clr-complementary),
-        227px 0 0 -8px var(--clr-complementary),
-        228px 0 0 -8px var(--clr-complementary),
-        229px 0 0 -8px var(--clr-complementary),
-        230px 0 0 -8px var(--clr-complementary),
-        231px 0 0 -8px var(--clr-complementary),
-        232px 0 0 -8px var(--clr-complementary),
-        233px 0 0 -8px var(--clr-complementary),
-        234px 0 0 -8px var(--clr-complementary),
-        235px 0 0 -8px var(--clr-complementary),
-        236px 0 0 -8px var(--clr-complementary),
-        237px 0 0 -8px var(--clr-complementary),
-        238px 0 0 -8px var(--clr-complementary),
-        239px 0 0 -8px var(--clr-complementary),
-        240px 0 0 -8px var(--clr-complementary);
+        5px 0 0 -8px var(--clr-complementary, #f2edd9),
+        6px 0 0 -8px var(--clr-complementary, #f2edd9),
+        7px 0 0 -8px var(--clr-complementary, #f2edd9),
+        8px 0 0 -8px var(--clr-complementary, #f2edd9),
+        9px 0 0 -8px var(--clr-complementary, #f2edd9),
+        10px 0 0 -8px var(--clr-complementary, #f2edd9),
+        11px 0 0 -8px var(--clr-complementary, #f2edd9),
+        12px 0 0 -8px var(--clr-complementary, #f2edd9),
+        13px 0 0 -8px var(--clr-complementary, #f2edd9),
+        14px 0 0 -8px var(--clr-complementary, #f2edd9),
+        15px 0 0 -8px var(--clr-complementary, #f2edd9),
+        16px 0 0 -8px var(--clr-complementary, #f2edd9),
+        17px 0 0 -8px var(--clr-complementary, #f2edd9),
+        18px 0 0 -8px var(--clr-complementary, #f2edd9),
+        19px 0 0 -8px var(--clr-complementary, #f2edd9),
+        20px 0 0 -8px var(--clr-complementary, #f2edd9),
+        21px 0 0 -8px var(--clr-complementary, #f2edd9),
+        22px 0 0 -8px var(--clr-complementary, #f2edd9),
+        23px 0 0 -8px var(--clr-complementary, #f2edd9),
+        24px 0 0 -8px var(--clr-complementary, #f2edd9),
+        25px 0 0 -8px var(--clr-complementary, #f2edd9),
+        26px 0 0 -8px var(--clr-complementary, #f2edd9),
+        27px 0 0 -8px var(--clr-complementary, #f2edd9),
+        28px 0 0 -8px var(--clr-complementary, #f2edd9),
+        29px 0 0 -8px var(--clr-complementary, #f2edd9),
+        30px 0 0 -8px var(--clr-complementary, #f2edd9),
+        31px 0 0 -8px var(--clr-complementary, #f2edd9),
+        32px 0 0 -8px var(--clr-complementary, #f2edd9),
+        33px 0 0 -8px var(--clr-complementary, #f2edd9),
+        34px 0 0 -8px var(--clr-complementary, #f2edd9),
+        35px 0 0 -8px var(--clr-complementary, #f2edd9),
+        36px 0 0 -8px var(--clr-complementary, #f2edd9),
+        37px 0 0 -8px var(--clr-complementary, #f2edd9),
+        38px 0 0 -8px var(--clr-complementary, #f2edd9),
+        39px 0 0 -8px var(--clr-complementary, #f2edd9),
+        40px 0 0 -8px var(--clr-complementary, #f2edd9),
+        41px 0 0 -8px var(--clr-complementary, #f2edd9),
+        42px 0 0 -8px var(--clr-complementary, #f2edd9),
+        43px 0 0 -8px var(--clr-complementary, #f2edd9),
+        44px 0 0 -8px var(--clr-complementary, #f2edd9),
+        45px 0 0 -8px var(--clr-complementary, #f2edd9),
+        46px 0 0 -8px var(--clr-complementary, #f2edd9),
+        47px 0 0 -8px var(--clr-complementary, #f2edd9),
+        48px 0 0 -8px var(--clr-complementary, #f2edd9),
+        49px 0 0 -8px var(--clr-complementary, #f2edd9),
+        50px 0 0 -8px var(--clr-complementary, #f2edd9),
+        51px 0 0 -8px var(--clr-complementary, #f2edd9),
+        52px 0 0 -8px var(--clr-complementary, #f2edd9),
+        53px 0 0 -8px var(--clr-complementary, #f2edd9),
+        54px 0 0 -8px var(--clr-complementary, #f2edd9),
+        55px 0 0 -8px var(--clr-complementary, #f2edd9),
+        56px 0 0 -8px var(--clr-complementary, #f2edd9),
+        57px 0 0 -8px var(--clr-complementary, #f2edd9),
+        58px 0 0 -8px var(--clr-complementary, #f2edd9),
+        59px 0 0 -8px var(--clr-complementary, #f2edd9),
+        60px 0 0 -8px var(--clr-complementary, #f2edd9),
+        61px 0 0 -8px var(--clr-complementary, #f2edd9),
+        62px 0 0 -8px var(--clr-complementary, #f2edd9),
+        63px 0 0 -8px var(--clr-complementary, #f2edd9),
+        64px 0 0 -8px var(--clr-complementary, #f2edd9),
+        65px 0 0 -8px var(--clr-complementary, #f2edd9),
+        66px 0 0 -8px var(--clr-complementary, #f2edd9),
+        67px 0 0 -8px var(--clr-complementary, #f2edd9),
+        68px 0 0 -8px var(--clr-complementary, #f2edd9),
+        69px 0 0 -8px var(--clr-complementary, #f2edd9),
+        70px 0 0 -8px var(--clr-complementary, #f2edd9),
+        71px 0 0 -8px var(--clr-complementary, #f2edd9),
+        72px 0 0 -8px var(--clr-complementary, #f2edd9),
+        73px 0 0 -8px var(--clr-complementary, #f2edd9),
+        74px 0 0 -8px var(--clr-complementary, #f2edd9),
+        75px 0 0 -8px var(--clr-complementary, #f2edd9),
+        76px 0 0 -8px var(--clr-complementary, #f2edd9),
+        77px 0 0 -8px var(--clr-complementary, #f2edd9),
+        78px 0 0 -8px var(--clr-complementary, #f2edd9),
+        79px 0 0 -8px var(--clr-complementary, #f2edd9),
+        80px 0 0 -8px var(--clr-complementary, #f2edd9),
+        81px 0 0 -8px var(--clr-complementary, #f2edd9),
+        82px 0 0 -8px var(--clr-complementary, #f2edd9),
+        83px 0 0 -8px var(--clr-complementary, #f2edd9),
+        84px 0 0 -8px var(--clr-complementary, #f2edd9),
+        85px 0 0 -8px var(--clr-complementary, #f2edd9),
+        86px 0 0 -8px var(--clr-complementary, #f2edd9),
+        87px 0 0 -8px var(--clr-complementary, #f2edd9),
+        88px 0 0 -8px var(--clr-complementary, #f2edd9),
+        89px 0 0 -8px var(--clr-complementary, #f2edd9),
+        90px 0 0 -8px var(--clr-complementary, #f2edd9),
+        91px 0 0 -8px var(--clr-complementary, #f2edd9),
+        92px 0 0 -8px var(--clr-complementary, #f2edd9),
+        93px 0 0 -8px var(--clr-complementary, #f2edd9),
+        94px 0 0 -8px var(--clr-complementary, #f2edd9),
+        95px 0 0 -8px var(--clr-complementary, #f2edd9),
+        96px 0 0 -8px var(--clr-complementary, #f2edd9),
+        97px 0 0 -8px var(--clr-complementary, #f2edd9),
+        98px 0 0 -8px var(--clr-complementary, #f2edd9),
+        99px 0 0 -8px var(--clr-complementary, #f2edd9),
+        100px 0 0 -8px var(--clr-complementary, #f2edd9),
+        101px 0 0 -8px var(--clr-complementary, #f2edd9),
+        102px 0 0 -8px var(--clr-complementary, #f2edd9),
+        103px 0 0 -8px var(--clr-complementary, #f2edd9),
+        104px 0 0 -8px var(--clr-complementary, #f2edd9),
+        105px 0 0 -8px var(--clr-complementary, #f2edd9),
+        106px 0 0 -8px var(--clr-complementary, #f2edd9),
+        107px 0 0 -8px var(--clr-complementary, #f2edd9),
+        108px 0 0 -8px var(--clr-complementary, #f2edd9),
+        109px 0 0 -8px var(--clr-complementary, #f2edd9),
+        110px 0 0 -8px var(--clr-complementary, #f2edd9),
+        111px 0 0 -8px var(--clr-complementary, #f2edd9),
+        112px 0 0 -8px var(--clr-complementary, #f2edd9),
+        113px 0 0 -8px var(--clr-complementary, #f2edd9),
+        114px 0 0 -8px var(--clr-complementary, #f2edd9),
+        115px 0 0 -8px var(--clr-complementary, #f2edd9),
+        116px 0 0 -8px var(--clr-complementary, #f2edd9),
+        117px 0 0 -8px var(--clr-complementary, #f2edd9),
+        118px 0 0 -8px var(--clr-complementary, #f2edd9),
+        119px 0 0 -8px var(--clr-complementary, #f2edd9),
+        120px 0 0 -8px var(--clr-complementary, #f2edd9),
+        121px 0 0 -8px var(--clr-complementary, #f2edd9),
+        122px 0 0 -8px var(--clr-complementary, #f2edd9),
+        123px 0 0 -8px var(--clr-complementary, #f2edd9),
+        124px 0 0 -8px var(--clr-complementary, #f2edd9),
+        125px 0 0 -8px var(--clr-complementary, #f2edd9),
+        126px 0 0 -8px var(--clr-complementary, #f2edd9),
+        127px 0 0 -8px var(--clr-complementary, #f2edd9),
+        128px 0 0 -8px var(--clr-complementary, #f2edd9),
+        129px 0 0 -8px var(--clr-complementary, #f2edd9),
+        130px 0 0 -8px var(--clr-complementary, #f2edd9),
+        131px 0 0 -8px var(--clr-complementary, #f2edd9),
+        132px 0 0 -8px var(--clr-complementary, #f2edd9),
+        133px 0 0 -8px var(--clr-complementary, #f2edd9),
+        134px 0 0 -8px var(--clr-complementary, #f2edd9),
+        135px 0 0 -8px var(--clr-complementary, #f2edd9),
+        136px 0 0 -8px var(--clr-complementary, #f2edd9),
+        137px 0 0 -8px var(--clr-complementary, #f2edd9),
+        138px 0 0 -8px var(--clr-complementary, #f2edd9),
+        139px 0 0 -8px var(--clr-complementary, #f2edd9),
+        140px 0 0 -8px var(--clr-complementary, #f2edd9),
+        141px 0 0 -8px var(--clr-complementary, #f2edd9),
+        142px 0 0 -8px var(--clr-complementary, #f2edd9),
+        143px 0 0 -8px var(--clr-complementary, #f2edd9),
+        144px 0 0 -8px var(--clr-complementary, #f2edd9),
+        145px 0 0 -8px var(--clr-complementary, #f2edd9),
+        146px 0 0 -8px var(--clr-complementary, #f2edd9),
+        147px 0 0 -8px var(--clr-complementary, #f2edd9),
+        148px 0 0 -8px var(--clr-complementary, #f2edd9),
+        149px 0 0 -8px var(--clr-complementary, #f2edd9),
+        150px 0 0 -8px var(--clr-complementary, #f2edd9),
+        151px 0 0 -8px var(--clr-complementary, #f2edd9),
+        152px 0 0 -8px var(--clr-complementary, #f2edd9),
+        153px 0 0 -8px var(--clr-complementary, #f2edd9),
+        154px 0 0 -8px var(--clr-complementary, #f2edd9),
+        155px 0 0 -8px var(--clr-complementary, #f2edd9),
+        156px 0 0 -8px var(--clr-complementary, #f2edd9),
+        157px 0 0 -8px var(--clr-complementary, #f2edd9),
+        158px 0 0 -8px var(--clr-complementary, #f2edd9),
+        159px 0 0 -8px var(--clr-complementary, #f2edd9),
+        160px 0 0 -8px var(--clr-complementary, #f2edd9),
+        161px 0 0 -8px var(--clr-complementary, #f2edd9),
+        162px 0 0 -8px var(--clr-complementary, #f2edd9),
+        163px 0 0 -8px var(--clr-complementary, #f2edd9),
+        164px 0 0 -8px var(--clr-complementary, #f2edd9),
+        165px 0 0 -8px var(--clr-complementary, #f2edd9),
+        166px 0 0 -8px var(--clr-complementary, #f2edd9),
+        167px 0 0 -8px var(--clr-complementary, #f2edd9),
+        168px 0 0 -8px var(--clr-complementary, #f2edd9),
+        169px 0 0 -8px var(--clr-complementary, #f2edd9),
+        170px 0 0 -8px var(--clr-complementary, #f2edd9),
+        171px 0 0 -8px var(--clr-complementary, #f2edd9),
+        172px 0 0 -8px var(--clr-complementary, #f2edd9),
+        173px 0 0 -8px var(--clr-complementary, #f2edd9),
+        174px 0 0 -8px var(--clr-complementary, #f2edd9),
+        175px 0 0 -8px var(--clr-complementary, #f2edd9),
+        176px 0 0 -8px var(--clr-complementary, #f2edd9),
+        177px 0 0 -8px var(--clr-complementary, #f2edd9),
+        178px 0 0 -8px var(--clr-complementary, #f2edd9),
+        179px 0 0 -8px var(--clr-complementary, #f2edd9),
+        180px 0 0 -8px var(--clr-complementary, #f2edd9),
+        181px 0 0 -8px var(--clr-complementary, #f2edd9),
+        182px 0 0 -8px var(--clr-complementary, #f2edd9),
+        183px 0 0 -8px var(--clr-complementary, #f2edd9),
+        184px 0 0 -8px var(--clr-complementary, #f2edd9),
+        185px 0 0 -8px var(--clr-complementary, #f2edd9),
+        186px 0 0 -8px var(--clr-complementary, #f2edd9),
+        187px 0 0 -8px var(--clr-complementary, #f2edd9),
+        188px 0 0 -8px var(--clr-complementary, #f2edd9),
+        189px 0 0 -8px var(--clr-complementary, #f2edd9),
+        190px 0 0 -8px var(--clr-complementary, #f2edd9),
+        191px 0 0 -8px var(--clr-complementary, #f2edd9),
+        192px 0 0 -8px var(--clr-complementary, #f2edd9),
+        193px 0 0 -8px var(--clr-complementary, #f2edd9),
+        194px 0 0 -8px var(--clr-complementary, #f2edd9),
+        195px 0 0 -8px var(--clr-complementary, #f2edd9),
+        196px 0 0 -8px var(--clr-complementary, #f2edd9),
+        197px 0 0 -8px var(--clr-complementary, #f2edd9),
+        198px 0 0 -8px var(--clr-complementary, #f2edd9),
+        199px 0 0 -8px var(--clr-complementary, #f2edd9),
+        200px 0 0 -8px var(--clr-complementary, #f2edd9),
+        201px 0 0 -8px var(--clr-complementary, #f2edd9),
+        202px 0 0 -8px var(--clr-complementary, #f2edd9),
+        203px 0 0 -8px var(--clr-complementary, #f2edd9),
+        204px 0 0 -8px var(--clr-complementary, #f2edd9),
+        205px 0 0 -8px var(--clr-complementary, #f2edd9),
+        206px 0 0 -8px var(--clr-complementary, #f2edd9),
+        207px 0 0 -8px var(--clr-complementary, #f2edd9),
+        208px 0 0 -8px var(--clr-complementary, #f2edd9),
+        209px 0 0 -8px var(--clr-complementary, #f2edd9),
+        210px 0 0 -8px var(--clr-complementary, #f2edd9),
+        211px 0 0 -8px var(--clr-complementary, #f2edd9),
+        212px 0 0 -8px var(--clr-complementary, #f2edd9),
+        213px 0 0 -8px var(--clr-complementary, #f2edd9),
+        214px 0 0 -8px var(--clr-complementary, #f2edd9),
+        215px 0 0 -8px var(--clr-complementary, #f2edd9),
+        216px 0 0 -8px var(--clr-complementary, #f2edd9),
+        217px 0 0 -8px var(--clr-complementary, #f2edd9),
+        218px 0 0 -8px var(--clr-complementary, #f2edd9),
+        219px 0 0 -8px var(--clr-complementary, #f2edd9),
+        220px 0 0 -8px var(--clr-complementary, #f2edd9),
+        221px 0 0 -8px var(--clr-complementary, #f2edd9),
+        222px 0 0 -8px var(--clr-complementary, #f2edd9),
+        223px 0 0 -8px var(--clr-complementary, #f2edd9),
+        224px 0 0 -8px var(--clr-complementary, #f2edd9),
+        225px 0 0 -8px var(--clr-complementary, #f2edd9),
+        226px 0 0 -8px var(--clr-complementary, #f2edd9),
+        227px 0 0 -8px var(--clr-complementary, #f2edd9),
+        228px 0 0 -8px var(--clr-complementary, #f2edd9),
+        229px 0 0 -8px var(--clr-complementary, #f2edd9),
+        230px 0 0 -8px var(--clr-complementary, #f2edd9),
+        231px 0 0 -8px var(--clr-complementary, #f2edd9),
+        232px 0 0 -8px var(--clr-complementary, #f2edd9),
+        233px 0 0 -8px var(--clr-complementary, #f2edd9),
+        234px 0 0 -8px var(--clr-complementary, #f2edd9),
+        235px 0 0 -8px var(--clr-complementary, #f2edd9),
+        236px 0 0 -8px var(--clr-complementary, #f2edd9),
+        237px 0 0 -8px var(--clr-complementary, #f2edd9),
+        238px 0 0 -8px var(--clr-complementary, #f2edd9),
+        239px 0 0 -8px var(--clr-complementary, #f2edd9),
+        240px 0 0 -8px var(--clr-complementary, #f2edd9);
 }
 
-/* ---------------------------  */
 /* -------- UTILITIES --------  */
-/* ---------------------------  */
 
 .sr-only {
     position: absolute;
-    width: 1px;
-    height: 1px;
+    inline-size: 1px;
+    block-size: 1px;
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(0%);
     white-space: nowrap;
     border: 0;
 }
@@ -376,58 +285,61 @@ select {
     cursor: pointer;
     font-size: 1rem;
     display: inline-flex;
+    flex-wrap: nowrap;
     align-items: center;
 }
 
 .chevron-wrapper {
     display: inline-block;
-    transition: transform 0.15s ease;
-}
+    transform: rotate(0);
 
-.chevron-wrapper.expanded {
-    transform: rotate(90deg);
+    @media (prefers-reduced-motion: no-preference) {
+        .chevron-wrapper {
+            transition: transform 0.15s ease;
+        }
+    }
+
+    &.expanded {
+        transform: rotate(90deg);
+    }
 }
 
 .collapse:hover {
-    color: var(--clr-accent-light);
+    color: var(--clr-accent-light, #404f4c);
 }
 
 .description {
-    margin-bottom: var(--mb-sm);
+    margin-block-end: var(--mb-sm, 0.5rem);
 }
 
-/* ---------------------------  */
 /* --------- GLOBAL ----------  */
-/* ---------------------------  */
 
 html {
-    background-color: var(--clr-accent);
+    background-color: var(--clr-accent, #404f4c);
 }
 
 body {
-    font-family: 'Montserrat', sans-serif;
+    font-family: Montserrat, sans-serif;
     user-select: none;
 }
 
 main {
-    margin-top: 50px;
+    margin-block-start: 50px;
     padding: 2rem;
 }
 
 h1,
 h2 {
-    color: var(--text-color);
+    color: var(--text-color, #b8a886);
 }
 
 h2 {
     font-size: 1.25rem;
-    margin-bottom: var(--mb-sm);
-    text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.63);
+    margin-block-end: var(--mb-sm, 0.5rem);
+    text-shadow: 1px 1px 0 rgb(0 0 0 / 63%);
 }
 
-/* ---------------------------  */
 /* ------- COMPONENTS --------  */
-/* ---------------------------  */
 
 /* buttons  */
 
@@ -435,28 +347,34 @@ h2 {
     font-size: 0.8rem;
     font-weight: 600;
     cursor: pointer;
-    background-color: var(--clr-accent-light);
-    color: var(--text-color);
-    border: 1px solid var(--clr-accent-light);
+    background-color: var(--clr-accent-light, #404f4c);
+    color: var(--text-color, #b8a886);
+    border: 1px solid var(--clr-accent-light, #404f4c);
     border-radius: 3px;
     flex: 1;
     padding: 0.3rem;
-    transition: all cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.2s;
-}
 
-.main-button:hover {
-    background-color: var(--clr-accent-light);
-    border: 1px solid var(--clr-light);
-    color: var(--clr-complementary);
-}
+    @media (prefers-reduced-motion: no-preference) {
+        transition:
+            background-color var(--cubic-bezier-transition, 0.2s ease),
+            border-color var(--cubic-bezier-transition, 0.2s ease),
+            color var(--cubic-bezier-transition, 0.2s ease);
+    }
 
-.main-button:active {
-    color: var(--clr-light);
-}
+    &:hover {
+        background-color: var(--clr-accent-light, #404f4c);
+        border: 1px solid var(--clr-light, #fff);
+        color: var(--clr-complementary, #f2edd9);
+    }
 
-.main-button:focus-visible {
-    outline: 3px solid var(--clr-complementary);
-    outline-offset: 2px;
+    &:active {
+        color: var(--clr-light, #fff);
+    }
+
+    &:focus-visible {
+        outline: 3px solid var(--clr-complementary, #f2edd9);
+        outline-offset: 2px;
+    }
 }
 
 .secondary-button {
@@ -464,65 +382,71 @@ h2 {
     font-weight: 600;
     cursor: pointer;
     background-color: white;
-    color: var(--clr-main);
-    border: 1px solid var(--clr-complementary);
+    color: var(--clr-main, #404f4c);
+    border: 1px solid var(--clr-complementary, #f2edd9);
     border-radius: 3px;
     padding: 0.4rem 1rem;
-    transition: all cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.2s;
-}
+    box-shadow: 0 0 0 0 transparent;
 
-.secondary-button:hover {
-    border: 1px solid var(--clr-main);
-}
+    @media (prefers-reduced-motion: no-preference) {
+        transition:
+            border-color var(--cubic-bezier-transition, 0.2s ease),
+            color var(--cubic-bezier-transition, 0.2s ease),
+            box-shadow var(--cubic-bezier-transition, 0.2s ease);
+    }
 
-.secondary-button:active {
-    color: var(--clr-complementary);
-    box-shadow: 1px 1px 0 0 var(--clr-main);
-}
+    &:hover {
+        border: 1px solid var(--clr-main, #404f4c);
+    }
 
-.secondary-button:focus-visible {
-    outline: 3px solid var(--clr-accent);
-    outline-offset: 2px;
+    &:active {
+        color: var(--clr-complementary, #f2edd9);
+        box-shadow: 1px 1px 0 0 var(--clr-main, #404f4c);
+    }
+
+    &:focus-visible {
+        outline: 3px solid var(--clr-accent, #404f4c);
+        outline-offset: 2px;
+    }
 }
 
 /* panels  */
 
 .panel {
-    border: var(--bd-lg) solid var(--clr-main);
-    border-radius: var(--base-radius);
+    border: var(--bd-lg, 1rem) solid var(--clr-main, #404f4c);
+    border-radius: var(--base-radius, 0.5rem);
     padding: 1.5rem;
-    background-color: var(--clr-light);
-    margin-bottom: var(--mb-lg);
-    height: 100%;
-    max-height: 100%;
+    background-color: var(--clr-light, #fff);
+    margin-block-end: var(--mb-lg, 1.5rem);
+    block-size: 100%;
+    max-block-size: 100%;
     overflow: hidden;
-    color: var(--clr-main);
+    color: var(--clr-main, #404f4c);
 }
 
 .panel-header {
-    color: var(--clr-main);
-    margin-bottom: var(--mb-md);
+    color: var(--clr-main, #404f4c);
+    margin-block-end: var(--mb-md, 1rem);
 }
 
-/* ---------------------------  */
 /* -------- SECTIONS ---------  */
-/* ---------------------------  */
 
 /* ----- NAVBAR ----- */
 
 nav {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 50px;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    inline-size: 100%;
+    block-size: 50px;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     padding: 0 2rem;
-    background-color: var(--clr-main);
-    color: var(--text-color);
-    box-shadow: 0 6px 10px rgba(0, 0, 0, 0.33);
+    background-color: var(--clr-main, #404f4c);
+    color: var(--text-color, #b8a886);
+    box-shadow: 0 6px 10px rgb(0 0 0 / 33%);
 }
 
 .brand {
@@ -533,221 +457,244 @@ nav {
 
 #logo {
     display: inline-block;
-    width: 24px;
-    height: 24px;
+    inline-size: 24px;
+    block-size: 24px;
     filter: invert(0.72);
-    margin-right: 0.3rem;
-    margin-bottom: -3px;
+    margin-inline-end: 0.3rem;
+    margin-block-end: -3px;
 }
 
 nav .title {
     font-size: 1.5rem;
-    color: var(--clr-complementary);
+    color: var(--clr-complementary, #f2edd9);
     text-shadow: 2px 2px 1px black;
 }
 
 .nav-links ul {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 1.5rem;
+
+    & li {
+        color: var(--text-color, #b8a886);
+        cursor: pointer;
+        border-radius: 0;
+    }
 }
 
-.nav-links ul li {
-    color: var(--text-color);
-    cursor: pointer;
-    transition: all cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.2s;
+@media (prefers-reduced-motion: no-preference) {
+    .nav-links ul li {
+        transition:
+            color var(--cubic-bezier-transition, 0.2s ease),
+            border-radius var(--cubic-bezier-transition, 0.2s ease);
+    }
 }
 
 .nav-links ul li:hover {
-    color: var(--clr-accent-light);
+    color: var(--clr-accent-light, #404f4c);
 }
 
 .nav-links ul li:focus-visible {
-    outline: 3px solid var(--clr-complementary);
+    outline: 3px solid var(--clr-complementary, #f2edd9);
     outline-offset: 4px;
     border-radius: 2px;
 }
 
 .fa-window-minimize {
-    margin-bottom: 5px;
+    margin-block-end: 5px;
 }
 
 /* Media Queries  */
 
 /* small  */
-@media (min-width: 461px) and (max-width: 768px) {
+@media (width >= 461px) and (width <= 768px) {
     nav {
         padding: 1.5rem;
-    }
-    nav #logo {
-        width: 18px;
-        height: 18px;
-        margin-right: 0.2rem;
-        margin-bottom: -2px;
-    }
-    nav .brand .title {
-        font-size: 0.95rem;
-    }
-    nav .nav-links ul {
-        gap: 1rem;
-        font-size: 0.85rem;
+
+        & #logo {
+            inline-size: 18px;
+            block-size: 18px;
+            margin-inline-end: 0.2rem;
+            margin-block-end: -2px;
+        }
+
+        & .brand .title {
+            font-size: 0.95rem;
+        }
+
+        & .nav-links ul {
+            gap: 1rem;
+            font-size: 0.85rem;
+        }
     }
 }
 
 /* extra small  */
-@media (max-width: 460px) {
+@media (width <= 460px) {
     nav {
         padding: 0 1rem;
-    }
-    nav #logo {
-        width: 12px;
-        height: 12px;
-        margin-right: 0.1rem;
-        margin-bottom: 0;
-    }
-    nav .brand .title {
-        font-size: 0.85rem;
-    }
-    nav .nav-links ul {
-        gap: 0.5rem;
-        font-size: 0.7rem;
+
+        & #logo {
+            inline-size: 12px;
+            block-size: 12px;
+            margin-inline-end: 0.1rem;
+            margin-block-end: 0;
+        }
+
+        & .brand .title {
+            font-size: 0.85rem;
+        }
+
+        & .nav-links ul {
+            gap: 0.5rem;
+            font-size: 0.7rem;
+        }
     }
 }
 
 /* ----- UTILITY BUTTONS BAR ----- */
 
 .utility-buttons {
-    margin-bottom: var(--mb-lg);
-    background: var(--clr-light);
+    margin-block-end: var(--mb-lg, 1.5rem);
+    background: var(--clr-light, #fff);
     padding: 20px 40px;
-    border-radius: var(--base-radius);
-    border: 10px solid var(--clr-main);
+    border-radius: var(--base-radius, 0.5rem);
+    border: 10px solid var(--clr-main, #404f4c);
     display: flex;
     flex-wrap: wrap;
     gap: 20px;
-}
 
-.utility-buttons button {
-    box-shadow: 1px 1px 1px var(--clr-accent);
-    border: 1px solid var(--clr-accent-light);
-}
+    & button {
+        box-shadow: 1px 1px 1px var(--clr-accent, #404f4c);
+        border: 1px solid var(--clr-accent-light, #404f4c);
+    }
 
-.utility-buttons button:active {
-    box-shadow: 2px 2px 1px var(--clr-accent);
+    & button:active {
+        box-shadow: 2px 2px 1px var(--clr-accent, #404f4c);
+    }
 }
 
 /* ----- MAIN COLOR BAR ----- */
 
 .main-color-bar {
-    width: 100%;
-    height: 100%;
-    margin-bottom: var(--mb-lg);
+    inline-size: 100%;
+    block-size: 100%;
+    margin-block-end: var(--mb-lg, 1.5rem);
     padding: 0.75rem 1.5rem;
-    color: var(--text-color);
-    background-color: var(--clr-main);
-    border-radius: var(--base-radius);
+    color: var(--text-color, #b8a886);
+    background-color: var(--clr-main, #404f4c);
+    border-radius: var(--base-radius, 0.5rem);
     display: flex;
+    flex-wrap: nowrap;
     justify-content: center;
     align-items: center;
     gap: 1.5rem;
     overflow: hidden;
-}
 
-.main-color-bar .main-button {
-    min-width: fit-content;
-    padding-inline: 15px;
-}
+    & .main-button {
+        min-inline-size: fit-content;
+        padding-inline: 15px;
+    }
 
-.main-color-bar .inputs-wrapper {
-    display: flex;
-    gap: 1.5rem;
-    width: 100%;
-}
+    & .inputs-wrapper {
+        display: flex;
+        flex-wrap: nowrap;
+        gap: 1.5rem;
+        inline-size: 100%;
+    }
 
-.main-color-bar .inputs-wrapper > form {
-    flex: 1;
-}
+    & .inputs-wrapper > form {
+        flex: 1;
+    }
 
-.main-color-bar .input-wrapper {
-    display: flex;
-    flex: 1;
-    width: 100%;
-    background: white;
-    border-radius: 2px;
-    padding-right: 3px;
-    align-items: center;
-}
+    & .input-wrapper {
+        display: flex;
+        flex-wrap: nowrap;
+        flex: 1;
+        inline-size: 100%;
+        background: white;
+        border-radius: 2px;
+        padding-inline-end: 3px;
+        align-items: center;
+    }
 
-.main-color-bar .input-wrapper input {
-    padding-inline: 6px;
-    outline: none;
-    background: transparent;
-    border: 0;
-    width: 100%;
-    min-width: 50px;
-}
+    & .input-wrapper input {
+        padding-inline: 6px;
+        background: transparent;
+        border: 0;
+        inline-size: 100%;
+        min-inline-size: 50px;
+    }
 
-.main-color-bar .input-wrapper input:focus-visible {
-    outline: 2px solid var(--clr-accent);
-    outline-offset: 2px;
-    border-radius: 2px;
-}
+    & .input-wrapper input:focus-visible {
+        outline: 2px solid var(--clr-accent, #404f4c);
+        outline-offset: 2px;
+        border-radius: 2px;
+    }
 
-.main-color-bar .input-wrapper input:invalid + button {
-    opacity: 0.25;
-    pointer-events: none;
-}
+    & .input-wrapper button {
+        padding: 3px;
+        border: 0;
+        background: transparent;
+        color: var(--clr-accent-light, #404f4c);
+    }
 
-.main-color-bar .input-wrapper input:valid + button {
-    cursor: pointer;
-}
+    & .input-wrapper button:hover {
+        color: var(--clr-accent, #404f4c);
+    }
 
-.main-color-bar .input-wrapper button {
-    padding: 3px;
-    border: 0;
-    background: transparent;
-    color: var(--clr-accent-light);
-}
+    & .input-wrapper input:invalid + button {
+        opacity: 0.25;
+        pointer-events: none;
+    }
 
-.main-color-bar .input-wrapper button:hover {
-    color: var(--clr-accent);
+    & .input-wrapper input:valid + button {
+        cursor: pointer;
+    }
 }
 
 /* Media Queries  */
 
 /* medium  */
-@media (min-width: 769px) and (max-width: 1024px) {
+@media (width >= 769px) and (width <= 1024px) {
     .main-color-bar {
         flex-wrap: wrap;
         gap: 1rem;
-    }
-    .main-color-bar .main-button {
-        order: -2;
-    }
-    .main-color-bar .inputs-wrapper {
-        gap: 1rem;
-    }
-    .main-color-bar form:last-of-type {
-        order: -1;
-        flex: 1;
-    }
-    .main-color-bar form:last-of-type input {
-        width: 100%;
+
+        & .main-button {
+            order: -2;
+        }
+
+        & .inputs-wrapper {
+            gap: 1rem;
+        }
+
+        & form:last-of-type {
+            order: -1;
+            flex: 1;
+        }
+
+        & form:last-of-type input {
+            inline-size: 100%;
+        }
     }
 }
 
 /* small  */
-@media (max-width: 768px) {
+@media (width <= 768px) {
     .main-color-bar {
         flex-direction: column;
-    }
-    .main-color-bar .main-button,
-    .main-color-bar form,
-    .main-color-bar form input {
-        width: 100%;
-    }
-    .main-color-bar .inputs-wrapper {
-        flex-direction: column;
+
+        & .main-button,
+        & form,
+        & form input {
+            inline-size: 100%;
+        }
+
+        & .inputs-wrapper {
+            flex-direction: column;
+        }
     }
 }
 
@@ -756,28 +703,28 @@ nav .title {
 /* slot labels  */
 
 .label {
-    color: var(--clr-accent);
+    color: var(--clr-accent, #404f4c);
     font-size: 1rem;
     padding: 4px;
-    max-width: 100%;
-    margin-bottom: 0.5rem;
-}
+    max-inline-size: 100%;
+    margin-block-end: 0.5rem;
 
-.label input {
-    font-family: 'JetBrains Mono', monospace;
-    text-align: center;
-    border: 0;
-    width: 80%;
-    border-radius: 3px;
-    cursor: pointer;
-}
+    & input {
+        font-family: 'JetBrains Mono', monospace;
+        text-align: center;
+        border: 0;
+        inline-size: 80%;
+        border-radius: 3px;
+        cursor: pointer;
+    }
 
-.label:hover input {
-    background: var(--clr-complementary);
-}
+    &:hover input {
+        background: var(--clr-complementary, #f2edd9);
+    }
 
-.label.icon {
-    color: var(--clr-accent);
+    &.icon {
+        color: var(--clr-accent, #404f4c);
+    }
 }
 
 /* color slots  */
@@ -799,12 +746,12 @@ nav .title {
 /* individual slot  */
 
 .color-slot {
-    width: var(--slot-size);
-    height: var(--slot-size);
-    border: 1px solid var(--clr-accent);
-    border-radius: var(--base-radius);
-    background-color: var(--clr-complementary);
-    box-shadow: 0 2px 3px 0 var(--clr-accent);
+    inline-size: var(--slot-size, 120px);
+    block-size: var(--slot-size, 120px);
+    border: 1px solid var(--clr-accent, #404f4c);
+    border-radius: var(--base-radius, 0.5rem);
+    background-color: var(--clr-complementary, #f2edd9);
+    box-shadow: 0 2px 3px 0 var(--clr-accent, #404f4c);
     display: flex;
     gap: 0.5rem;
     flex-direction: column;
@@ -814,98 +761,100 @@ nav .title {
     line-height: 1.2rem;
     font-weight: 500;
     letter-spacing: 0.8px;
-    margin-bottom: var(--mb-md);
+    margin-block-end: var(--mb-md, 1rem);
 }
 
 /* slot controls  */
 
 .color-controls {
-    border: 1px solid var(--clr-accent);
-    background-color: #fff;
-    border-radius: var(--base-radius);
+    border: 1px solid var(--clr-accent, #404f4c);
+    background-color: var(--clr-light, #d9def2);
+    border-radius: var(--base-radius, 0.5rem);
     padding: 0.3rem 1rem;
-    box-shadow: 0 1px 4px 1px var(--clr-complementary);
-}
+    box-shadow: 0 1px 4px 1px var(--clr-complementary, #f2edd9);
 
-.color-controls fieldset {
-    border: 0;
-    padding: 0;
-    margin: 0;
-}
+    & fieldset {
+        border: 0;
+        padding: 0;
+        margin: 0;
+    }
 
-.color-controls .control-field {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
+    & .control-field {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+    }
 
-.color-controls .control-field label {
-    color: var(--clr-main);
-    font-size: 0.8rem;
-    font-weight: 900;
-    letter-spacing: 0.8px;
-    margin-bottom: 0.4rem;
+    & .control-field label {
+        color: var(--clr-main, #404f4c);
+        font-size: 0.8rem;
+        font-weight: 900;
+        letter-spacing: 0.8px;
+        margin-block-end: 0.4rem;
+    }
 }
 
 /* custom range control  */
 
 .color-controls input[type='range'] {
-    max-width: 75%;
+    max-inline-size: 75%;
     align-items: center;
-    -webkit-appearance: none;
-    -moz-appearance: none;
     appearance: none;
     background: none;
     cursor: pointer;
     display: flex;
-    height: 100%;
-    min-height: 30px;
+    flex-wrap: wrap;
+    block-size: 100%;
+    min-block-size: 30px;
     overflow: hidden;
-}
 
-.color-controls input[type='range']:focus {
-    box-shadow: none;
-    outline: none;
+    &:focus-visible {
+        box-shadow: none;
+        outline: none;
+    }
 }
 
 .color-controls input[type='range']::-webkit-slider-runnable-track {
-    background: var(--clr-accent-light);
+    background: var(--clr-accent-light, #404f4c);
     content: '';
-    height: 2px;
+    block-size: 2px;
     pointer-events: none;
 }
 
 .color-controls input[type='range']::-webkit-slider-thumb {
-    height: 18px;
-    width: 28px;
-    -webkit-appearance: none;
+    block-size: 18px;
+    inline-size: 28px;
     appearance: none;
     background: #fff;
     border-radius: 8px;
-    box-shadow: var(--slider-thumb-dots);
-    margin-top: -8px;
-    border: 1px solid var(--clr-accent-light);
+    box-shadow: var(
+        --slider-thumb-dots,
+        1px 1px 0 0 var(--clr-complementary, #f2edd9)
+    );
+    margin-block-start: -8px;
+    border: 1px solid var(--clr-accent-light, #404f4c);
 }
 
 .color-controls input[type='range']::-moz-range-track {
-    width: 240px;
-    height: 2px;
+    inline-size: 240px;
+    block-size: 2px;
 }
 
 .color-controls input[type='range']::-moz-range-thumb {
-    height: 18px;
-    width: 28px;
+    block-size: 18px;
+    inline-size: 28px;
     background: #fff;
     border-radius: 8px;
-    border: 1px solid var(--clr-accent-light);
+    border: 1px solid var(--clr-accent-light, #404f4c);
     position: relative;
 }
 
 .color-controls input[type='range']::-moz-range-progress {
-    height: 2px;
-    background: var(--clr-accent-light);
+    block-size: 2px;
+    background: var(--clr-accent-light, #404f4c);
     border: 0;
-    margin-top: 0;
+    margin-block-start: 0;
 }
 
 .color-controls input[type='range']::-ms-track {
@@ -913,28 +862,27 @@ nav .title {
     border: 0;
     border-color: transparent;
     border-radius: 0;
-    border-width: 0;
     color: transparent;
-    height: 2px;
-    margin-top: 10px;
-    width: 240px;
+    block-size: 2px;
+    margin-block-start: 10px;
+    inline-size: 240px;
 }
 
 .color-controls input[type='range']::-ms-thumb {
-    height: 18px;
-    width: 28px;
+    block-size: 18px;
+    inline-size: 28px;
     background: #fff;
     border-radius: 8px;
-    border: 1px solid var(--clr-accent-light);
+    border: 1px solid var(--clr-accent-light, #404f4c);
 }
 
 .color-controls input[type='range']::-ms-fill-lower {
-    background: var(--clr-complementary);
+    background: var(--clr-complementary, #f2edd9);
     border-radius: 0;
 }
 
 .color-controls input[type='range']::-ms-fill-upper {
-    background: var(--clr-complementary);
+    background: var(--clr-complementary, #f2edd9);
     border-radius: 0;
 }
 
@@ -946,36 +894,39 @@ nav .title {
 
 .mini-slots-slots {
     display: grid;
-    grid-template-columns: repeat(auto-fill, var(--mini-slot-size));
+    grid-template-columns: repeat(auto-fill, var(--mini-slot-size, 50px));
     gap: 1.5rem;
-    margin-bottom: var(--mb-lg);
+    margin-block-end: var(--mb-lg, 1.5rem);
     justify-content: center;
 }
 
 .mini-slot {
-    width: var(--mini-slot-size);
-    height: var(--mini-slot-size);
-    border: 1px solid var(--clr-main);
+    inline-size: var(--mini-slot-size, 50px);
+    block-size: var(--mini-slot-size, 50px);
+    border: 1px solid var(--clr-main, #404f4c);
     border-radius: 50%;
     cursor: pointer;
     box-shadow:
-        2px 2px 2px rgba(0, 0, 0, 0.2),
-        inset 2px 2px 2px rgba(233, 233, 233, 0.4);
-    transition: box-shadow 0.075s ease-in-out;
-}
+        2px 2px 2px rgb(0 0 0 / 20%),
+        inset 2px 2px 2px rgb(233 233 233 / 40%);
 
-.mini-slot:hover,
-.mini-slot:active {
-    box-shadow: none;
-}
+    @media (prefers-reduced-motion: no-preference) {
+        transition: box-shadow 0.075s ease-in-out;
+    }
 
-.mini-slot:focus-visible {
-    outline: 3px solid var(--clr-accent);
-    outline-offset: 3px;
+    &:hover,
+    &:active {
+        box-shadow: none;
+    }
+
+    &:focus-visible {
+        outline: 3px solid var(--clr-accent, #404f4c);
+        outline-offset: 3px;
+    }
 }
 
 .copied {
-    outline: var(--clr-complementary) solid 7px;
+    outline: var(--clr-complementary, #f2edd9) solid 7px;
     outline-offset: 3px;
 }
 
@@ -989,78 +940,88 @@ nav .title {
 }
 
 .saved-palette {
-    border: 1px solid var(--clr-main);
+    border: 1px solid var(--clr-main, #404f4c);
     padding: 0.5rem;
-    background-color: var(--clr-complementary);
-    transition: all 0.23s ease-in-out;
-}
+    background-color: var(--clr-complementary, #f2edd9);
+    color: var(--clr-main, #404f4c);
+    box-shadow: 0 0 0 0 transparent;
 
-.saved-palette:hover {
-    cursor: pointer;
-    background-color: var(--clr-accent-light);
-    color: var(--text-color);
-    border-color: var(--clr-light);
-    box-shadow:
-        1px 1px 0 1px var(--clr-main),
-        -1px -1px 0 1px var(--clr-main);
+    @media (prefers-reduced-motion: no-preference) {
+        transition:
+            color var(--cubic-bezier-transition, 0.25s ease-in-out),
+            background-color var(--cubic-bezier-transition, 0.25s ease-in-out),
+            border-color var(--cubic-bezier-transition, 0.25s ease-in-out),
+            box-shadow var(--cubic-bezier-transition, 0.25s ease-in-out);
+    }
+
+    &:hover {
+        cursor: pointer;
+        background-color: var(--clr-accent-light, #404f4c);
+        color: var(--text-color, #b8a886);
+        border-color: var(--clr-light, #f2edd9);
+        box-shadow:
+            1px 1px 0 1px var(--clr-main, #404f4c),
+            -1px -1px 0 1px var(--clr-main, #404f4c);
+    }
 }
 
 .saved-palette-header {
     display: flex;
+    flex-wrap: nowrap;
     justify-content: space-between;
 }
 
 .saved-palette-colors {
     display: flex;
+    flex-wrap: nowrap;
     justify-content: space-between;
 }
 
 .saved-palette-color {
-    width: 50px;
-    height: 50px;
+    inline-size: 50px;
+    block-size: 50px;
     border: 1px solid black;
 }
 
-@media (max-width: 420px) {
+@media (width <= 420px) {
     .palettes-wrapper {
         gap: 0.5rem;
     }
+
     .saved-palette-color {
-        width: 36px;
-        height: 36px;
+        inline-size: 36px;
+        block-size: 36px;
     }
 }
 
-/* ---------------------------  */
 /* --------- MODALS ----------  */
-/* ---------------------------  */
 
 /* ----- INSTRUCTIONS ----- */
 
 .instructions {
     margin: 0;
-    color: var(--clr-complementary);
-    background: var(--clr-accent);
+    color: var(--clr-complementary, #f2edd9);
+    background: var(--clr-accent, #404f4c);
     position: absolute;
+
+    & p {
+        text-align: start;
+        padding: 10px 30px;
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 500;
+    }
 }
 
-.instructions p {
-    text-align: left;
-    padding: 10px 30px;
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 500;
-}
-
-@media (max-width: 500px) {
+@media (width <= 500px) {
     .instructions p {
-        padding: 5px 5px;
+        padding: 5px;
         font-size: 0.7rem;
         font-weight: 400;
     }
 }
 
-@media (min-width: 501px) and (max-width: 900px) {
+@media (width >= 501px) and (width <= 900px) {
     .instructions p {
         padding: 5px 20px;
         font-size: 0.85rem;
@@ -1068,85 +1029,31 @@ nav .title {
     }
 }
 
-/* ----- SIGN IN ----- */
-
-.sign-in .inputs-wrapper {
-    padding: 1.3rem;
-}
-
-.sign-in .input-wrapper {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    margin-bottom: var(--mb-sm);
-}
-
-.sign-in .input-wrapper input {
-    padding: 0.2rem;
-}
-
-.sign-in .input-wrapper input::placeholder {
-    font-size: 0.9rem;
-}
-
-.sign-in .switch-mode-msg {
-    font-size: 0.9rem;
-}
-
-.sign-in .switch-mode-msg span {
-    cursor: pointer;
-    background-color: var(--clr-main);
-    padding: 0.2rem 0.4rem;
-    border-radius: var(--sm-radius);
-    transition: color 0.2s;
-    display: block;
-    margin: 0 auto;
-    max-width: 50%;
-}
-
-.sign-in .switch-mode-msg span:hover {
-    color: var(--clr-accent);
-}
-
-.sign-in .error-msg {
-    color: var(--clr-main);
-    font-size: 0.9rem;
-    margin-top: 0.5rem;
-}
-
-@media (max-width: 460px) {
-    .sign-in .input-wrapper {
-        flex-direction: column;
-    }
-}
-
 /* ----- EXPORT CSS ----- */
 
 .export-modal-buttons button {
-    margin-right: 2px;
+    margin-inline-end: 2px;
 }
 
 .code {
-    border: 1px solid var(--clr-main);
-    text-align: left;
+    border: 1px solid var(--clr-main, #404f4c);
+    text-align: start;
     padding: 1rem;
-    background-color: var(--clr-main);
-    margin-top: 1.5rem;
-    -webkit-user-select: all; /* for Safari */
+    background-color: var(--clr-main, #404f4c);
+    margin-block-start: 1.5rem;
     user-select: all;
     cursor: pointer;
-}
 
-.code p {
-    font-size: 0.8rem;
-    line-height: 1.4rem;
+    & p {
+        font-size: 0.8rem;
+        line-height: 1.4rem;
+    }
 }
 
 .code-info {
     text-align: center;
-    color: var(--clr-light);
-    margin-bottom: 0.3rem;
+    color: var(--clr-light, #f2edd9);
+    margin-block-end: 0.3rem;
     font-weight: 600;
 }
 
@@ -1158,15 +1065,15 @@ nav .title {
 /* ----- SAVE MODAL ----- */
 
 .save-input {
-    margin: var(--mb-lg);
+    margin: var(--mb-lg, 1rem);
 }
 
 .invalid {
-    outline: var(--clr-accent-light) solid 5px;
+    outline: var(--clr-accent-light, #404f4c) solid 5px;
 }
 
 .save-modal-footer button {
-    margin-right: 2px;
+    margin-inline-end: 2px;
     padding: 4px 8px;
 }
 
@@ -1175,44 +1082,41 @@ nav .title {
 .modal-mask {
     position: fixed;
     z-index: 9998;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.65);
+    inset: 0;
+    background-color: rgb(0 0 0 / 65%);
     display: table;
 }
 
 .modal-wrapper {
     display: grid;
     place-items: center;
-    height: 100vh;
+    block-size: 100dvh;
 }
 
 .modal-container {
     display: grid;
     place-items: center;
-    width: 100vw;
-    width: max-content;
-    max-width: 55%;
-    margin: 0px auto;
+    inline-size: 100vw;
+    inline-size: max-content;
+    max-inline-size: 55%;
+    margin: 0 auto;
     padding: 20px 30px;
-    background-color: var(--clr-accent);
-    color: var(--text-color);
+    background-color: var(--clr-accent, #404f4c);
+    color: var(--text-color, #b8a886);
     border-radius: 2px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 33%);
     font-family: 'JetBrains Mono', monospace;
 }
 
 .modal-header {
-    width: 100%;
-    border-bottom: 1px solid var(--clr-main);
-}
+    inline-size: 100%;
+    border-block-end: 1px solid var(--clr-main, #404f4c);
 
-.modal-header h3 {
-    font-size: 1.3rem;
-    margin-top: 0;
-    color: var(--text-color);
+    & h3 {
+        font-size: 1.3rem;
+        margin-block-start: 0;
+        color: var(--text-color, #b8a886);
+    }
 }
 
 .modal-body {
@@ -1222,33 +1126,33 @@ nav .title {
 
 .footer-msg {
     font-size: 0.9rem;
-    color: var(--text-color);
-    margin-left: 1rem;
+    color: var(--text-color, #b8a886);
+    margin-inline-start: 1rem;
+
+    & > * {
+        font-size: 1.5rem;
+        margin-inline-end: 0.4rem;
+        color: var(--clr-complementary, #404f4c);
+        font-weight: 900;
+    }
 }
 
-.footer-msg > * {
-    font-size: 1.5rem;
-    margin-right: 0.4rem;
-    color: var(--clr-complementary);
-    font-weight: 900;
-}
-
-@media (max-width: 400px) {
+@media (width <= 400px) {
     .modal-container {
-        max-width: 90vw;
+        max-inline-size: 90vw;
         padding: 5px 10px;
     }
 }
 
-@media (min-width: 401px) and (max-width: 640px) {
+@media (width >= 401px) and (width <= 640px) {
     .modal-container {
-        max-width: 90vw;
+        max-inline-size: 90vw;
     }
 }
 
-@media (min-width: 641px) and (max-width: 900px) {
+@media (width >= 641px) and (width <= 900px) {
     .modal-container {
-        max-width: 70%;
+        max-inline-size: 70%;
     }
 }
 
@@ -1262,13 +1166,25 @@ nav .title {
 
 .modal-enter-active,
 .modal-leave-active {
-    transition:
-        opacity 0.5s ease,
-        transform 0.3s ease-out;
+    opacity: 1;
+    transform: translateX(0);
 }
 
 .modal-enter-from,
 .modal-leave-to {
     opacity: 0;
-    transform: translateX(-100%);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    .modal-enter-active,
+    .modal-leave-active {
+        transition:
+            opacity 0.5s ease,
+            transform 0.3s ease-out;
+    }
+
+    .modal-enter-from,
+    .modal-leave-to {
+        transform: translateX(-100%);
+    }
 }

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -1,0 +1,69 @@
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    text-rendering: optimizelegibility;
+}
+
+/* Remove default margin */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+    margin: 0;
+}
+
+h1,
+h2 {
+    font-family: 'JetBrains Mono', monospace;
+}
+
+/* Remove list styles on ul, ol elements  */
+ul,
+ol {
+    list-style: '';
+}
+
+/* Set core root defaults */
+@media (prefers-reduced-motion: no-preference) {
+    html:focus-within {
+        scroll-behavior: smooth;
+    }
+}
+
+/* Set core body defaults */
+body {
+    min-block-size: 100dvh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizelegibility;
+    line-height: 1.5;
+    color: currentcolor;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+    text-decoration-skip-ink: auto;
+}
+
+/* Make images easier to work with */
+img,
+picture {
+    max-inline-size: 100%;
+    display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+    font: inherit;
+}

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,0 +1,46 @@
+// oxlint-disable import/no-anonymous-default-export
+
+/** @type {import("stylelint").Config} */
+export default {
+    extends: ['stylelint-config-standard'],
+    overrides: [
+        {
+            extends: ['stylelint-config-recommended-vue'],
+            files: ['**/*.vue'],
+        },
+    ],
+    plugins: [
+        'stylelint-plugin-defensive-css',
+        'stylelint-plugin-logical-css',
+        'stylelint-use-nesting',
+    ],
+    reportDescriptionlessDisables: true,
+    reportInvalidScopeDisables: true,
+    reportNeedlessDisables: true,
+    rules: {
+        'csstools/use-nesting': true,
+        'declaration-no-important': true,
+        'defensive-css/no-list-style-none': true,
+        'defensive-css/no-mixed-vendor-prefixes': true,
+        'defensive-css/no-unsafe-will-change': true,
+        'defensive-css/require-background-repeat': true,
+        'defensive-css/require-custom-property-fallback': true,
+        'defensive-css/require-dynamic-viewport-height': true,
+        'defensive-css/require-flex-wrap': true,
+        'defensive-css/require-focus-visible': true,
+        'defensive-css/require-overscroll-behavior': true,
+        'defensive-css/require-prefers-reduced-motion': true,
+        'defensive-css/require-scrollbar-gutter': true,
+        'function-url-no-scheme-relative': true,
+        'logical-css/require-logical-keywords': true,
+        'logical-css/require-logical-properties': [
+            true,
+            { fix: true, severity: 'warning' },
+        ],
+        'logical-css/require-logical-units': null,
+        'no-descending-specificity': null,
+        'no-unknown-animations': true,
+        'no-unknown-custom-media': true,
+        'no-unknown-custom-properties': true,
+    },
+};


### PR DESCRIPTION
Also, fixed bug where the saved palletes were not visible until you saved one.

- Introduced a CSS reset file to standardize styling across browsers, including box-sizing rules, default margins, and body styles.
- Added a Stylelint configuration file to enforce consistent styling practices, including rules for nesting, vendor prefixes, and logical CSS properties.