### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [master]
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rogerio-romao/pallete-creator/security/code-scanning/4](https://github.com/rogerio-romao/pallete-creator/security/code-scanning/4)

In general, fix this by explicitly adding a `permissions:` block that grants only the minimal access required. For a simple CI pipeline that only checks out code and runs local commands, `contents: read` is typically sufficient. Define this either at the top level of the workflow (to apply to all jobs) or inside the specific job.

For this workflow, the safest, non‑breaking change is to add a root‑level `permissions:` block after the `on:` section, setting `contents: read`. None of the listed steps require write access to the repository or other resources, so we don’t need any `write` scopes. Concretely, edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
    contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No imports or additional definitions are needed, and the workflow behavior (linting, testing, building) remains unchanged; only the implicit permissions of `GITHUB_TOKEN` are restricted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
